### PR TITLE
Update instructions to reference latest app availability

### DIFF
--- a/jellyfinwebos/index.md
+++ b/jellyfinwebos/index.md
@@ -1,15 +1,20 @@
-# Install Jellyfin on LG webOS Permanently
+# Jellyfin client is now available on all LG webOSes
+As of May 17, 2024, LG has approved the Jellyfin client for all webOSes ([link](https://github.com/jellyfin/jellyfin-webos/issues/169#issuecomment-2002719660)). As a result, the app is no longer available in the Web OS Dev Manager Apps but should now be availalbe in all webOS app stores. The below steps are no longer necessary, but have been left for reference.
+
+# *Legacy steps:*
+
+## Install Jellyfin on LG webOS Permanently
 Yes you read the title right, It is possible to install Jellyfin permanently on a LG webOS smart TV and that too without rooting your TV.
 
 Although I did make a guide nearly a year back, some new things have come to my attention that no longer require you to install a bulky IDE or have to extend developer mode every 50 hours.
 
-## Requirements
+### Requirements
 
 - Access to a computer (Linux, Windows, Mac whatever)
 
 - A LG Developer account. (If you dont have one sign up [here](https://webostv.developer.lge.com/develop/app-test/preparing-account/)) 
 
-## Setting Up the TV
+### Setting Up the TV
 
 On your WebOS TV go to the LG content store and download the Developer mode app. Open it up and Sign in.
 
@@ -17,7 +22,7 @@ Then 1) Enable Developer mode and restart your TV.
 
 Upon restart open up developer mode and enable the Key Server. Make note of the TV's ip address and Paraphrase you will need this later.
 
-## Configuring it from your PC
+### Configuring it from your PC
 
 Get the latest version of WebOS dev manager from webOS brew from [here](https://github.com/webosbrew/dev-manager-desktop) for your operating system and run it.
 
@@ -29,7 +34,7 @@ Get the latest version of WebOS dev manager from webOS brew from [here](https://
 
 There you go, Jelly fin is now installed.
 
-## Making the Install Permanent
+### Making the Install Permanent
 
 The way developer mode works is that it checks LG's servers to see if the time has run out or not. You can extend this by making a call to API. 
 


### PR DESCRIPTION
Since this is the top Google result for how to manually install the (old) Jellyfin app to webOS 4, adding a line at the top to indicate that this method is no longer necessary and the app is available natively in the webOS app stores.